### PR TITLE
Update <head> and other templates

### DIFF
--- a/_data/head.yml
+++ b/_data/head.yml
@@ -44,26 +44,6 @@ preload:
     as: image
     type: image/svg+xml
     name: icons
-  - href: /img/logos/Facebook.svg
-    as: image
-    type: image/svg+xml
-    name: Facebook
-  - href: /img/logos/twitter.svg
-    as: image
-    type: image/svg+xml
-    name: Twitter
-  - href: /img/logos/Google_plus.svg
-    as: image
-    type: image/svg+xml
-    name: Google+
-  - href: /img/logos/Reddit.svg
-    as: image
-    type: image/svg+xml
-    name: Reddit
-  - href: /img/logos/linkedin.svg
-    as: image
-    type: image/svg+xml
-    name: LinkedIn
 icons:
   - href: /img/favicon.svg
     type: image/svg+xml

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -71,7 +71,7 @@
 		<meta name="msapplication-TileColor" content="{{ site.theme-color }}" />
 	{% endif %}
 	{% if site.data.csp %}
-		<meta http-equiv="Content-Security-Policy" content="
+		<meta http-equiv="{% if jekyll.environment == 'production'%}Content-Security-Policy{% else %}Content-Security-Policy-Report-Only{% endif %}" content="
 				{% if site.data.csp.default %}default-src {{ site.data.csp.default | join: ' ' }};{% endif %}
 				{% if site.data.csp.img %}img-src {{ site.data.csp.img | join: ' ' }};{% endif %}
 				{% if site.data.csp.script %}script-src {{ site.data.csp.script | join: ' ' }};{% endif %}
@@ -90,20 +90,24 @@
 		<meta name="msvalidate.01" content="{{ site.webmaster-verifications.bing }}" />
 	{% endif %}
 	{% for script in site.data.head.scripts[jekyll.environment] %}
-		<script type="{{ script.type }}" src="{{ script.src | absolute_url }}"{% if script.async %} async=""{% endif %}{% if script.defer %} defer=""{% endif %}{% if script.nomodule %} nomodule=""{% endif %}></script>
+		<script type="{{ script.type }}" src="{{ script.src | absolute_url }}"{% if script.async %} async=""{% endif %}{% if script.defer %} defer=""{% endif %}{% if script.nomodule %} nomodule=""{% endif %}{% if script.crossorigin %} crossorigin="{{ script.crossorigin }}"{% endif %}{% if script.integrity %} integrity="{{ script.integrity }}"{% endif %}></script>
 	{% endfor %}
 	{% for stylesheet in site.data.head.stylesheets[jekyll.environment] %}
-		<link rel="stylesheet" href="{{ stylesheet.href | absolute_url }}" media="{{ stylesheet.media }}" />
+		<link rel="stylesheet" href="{{ stylesheet.href | absolute_url }}" media="{{ stylesheet.media }}"{% if stylesheet.crossorigin %} crossorigin="{{ stylesheet.crossorigin }}"{% endif %}{% if stylesheet.integrity %} integrity="{{ stylesheet.integrity }}"{% endif %} />
 	{% endfor %}
 	{% if  site.data.head.canonical %}<link rel="canonical" href="{{ site.data.head.canonical }}{{ page.url }}"/>{% endif %}
 	{% if site.data.head.icons %}{% for icon in site.data.head.icons %}
 		<link rel="icon" href="{{ icon.href | absolute_url }}" type="{{ icon.type }}" sizes="{{ icon.sizes }}" />
 	{% endfor %}{% endif %}
 	{% if site.data.head.touch-icons %}{% for icon in site.data.head.touch-icons %}
-	<link rel="apple-touch-icon" href="{{ icon.href | absolute_url }}" sizes="{{ icon.size }}x{{ icon.size }}" />
+		<link rel="apple-touch-icon" href="{{ icon.href | absolute_url }}" sizes="{{ icon.sizes }}" />
 	{% endfor %}{% endif %}
-	<link rel="mask-icon" href="{{ '/img/favicon.svg' | absolute_url }}" color="black" />
-	<meta name="msapplication-config" content="{{ 'browserconfig.xml' | absolute_url }}" />
+	{% if site.data.head.mask-icon %}
+		<link rel="mask-icon" href="{{ site.data.head.mask-icon.href | absolute_url }}" color="{{ site.data.head.mask-icon.color }}"/>
+	{% endif %}
+	{% if site.data.head.tiles %}
+		<meta name="msapplication-config" content="{{ 'browserconfig.xml' | absolute_url }}" />
+	{% endif %}
 	{% if site.data.head.windows-tile %}
 		<meta name="msapplication-TileImage" content="{{ site.data.head.windows-tile | absolute_url }}" />
 	{% endif %}

--- a/_includes/pinned-posts.html
+++ b/_includes/pinned-posts.html
@@ -9,7 +9,7 @@
 		{% for post in posts limit: 5 %}
 		<a href="{{ post.url | absolute_url }}" title="{{ post.title }}">
 			{% if post.image != null %}
-				<img src="{{ post.image | absolute_url }}" class="post-img" />
+				<img src="{{ post.image | absolute_url }}" class="post-img" crossorigin="anonymous" />
 			{% endif %}
 		</a>
 		<a href="{{ post.url | absolute_url }}" title="{{ post.title }}">

--- a/_includes/recent-posts.html
+++ b/_includes/recent-posts.html
@@ -1,4 +1,4 @@
-<aside role="complementary" itemtype="http://schema.org/WPSideBar" itemscope="" class="card shadow-dark" id="recent-posts">
+<aside role="complementary" itemtype="http://schema.org/WPSideBar" itemscope="" class="card shadow-dark" id="recent-posts" crossorigin="anonymous">
 		<h4 class="color-accent underline center">
 			<svg class="current-color icon">
 				<use xlink:href="{{ site.icons | absolute_url | append: '#recent' }}" />


### PR DESCRIPTION
Fixes #6
- Corrects sizes for touch icons
- Corrects pined-tab for Safari
- Adds support for `crossorigin="anonymous"` in scripts, stylesheets & imgs